### PR TITLE
Correcting red box path

### DIFF
--- a/launch/initialize.launch
+++ b/launch/initialize.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="red_box_path" type="str" value="/home/haoran/ros_hw/src/ur5_notebook/urdf/red_box.urdf"/>
+  <param name="red_box_path" type="str" value="$(find ur5_notebook)/urdf/red_box.urdf"/>
 
   <arg name="limited" default="true"/>
   <arg name="paused" default="false"/>


### PR DESCRIPTION
There was an error in the red box path in `initialize.launch`. Appropriate changes have been done. Please check.